### PR TITLE
fixed issues with 429s from Google Books API

### DIFF
--- a/literary-travels-api/.env.example
+++ b/literary-travels-api/.env.example
@@ -1,3 +1,4 @@
 WIKIDATA_EMAIL=your-email@example.com
 DATABASE_URL_POOLED="postgres://user:pass@host/dbname?sslmode=require"
 DATABASE_URL_DIRECT="postgres://user:pass@host/dbname?sslmode=require"
+GOOGLE_BOOKS_API_KEY='loremipsum'

--- a/literary-travels-api/src/services/GoogleBooksService.ts
+++ b/literary-travels-api/src/services/GoogleBooksService.ts
@@ -8,8 +8,8 @@ export interface BookMetadataDTO {
 }
 
 export const getBookMetadata = async (
-    isbn?: string | null, 
-    title?: string, 
+    isbn?: string | null,
+    title?: string,
     author?: string
 ): Promise<BookMetadataDTO | null> => {
     try {
@@ -17,13 +17,17 @@ export const getBookMetadata = async (
 
         if (isbn) {
             query = `isbn:${isbn}`;
-        } else if (title && author) {
-            query = `intitle:"${title}"+inauthor:"${author}"`;
+        } else if (title) {
+            query = `intitle:"${title}"`;
+            if (author && author !== 'Unknown') {
+                query += `+inauthor:"${author}"`;
+            }
         } else {
             throw new Error('Must provide either an ISBN or Title/Author pair for metadata search.');
         }
 
-        const url = `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(query)}&maxResults=1`;
+        const apiKey = process.env.GOOGLE_BOOKS_API_KEY;
+        const url = `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(query)}&maxResults=1${apiKey ? `&key=${apiKey}` : ''}`;
         const response = await axios.get(url);
 
         if (!response.data.items || response.data.items.length === 0) {

--- a/literary-travels-api/src/services/WikidataService.ts
+++ b/literary-travels-api/src/services/WikidataService.ts
@@ -69,7 +69,7 @@ export const getBooksByLocation = async (wikidataId: string, locationName: strin
                 const bookId = wikidataUri ? wikidataUri.split('/').pop() : null;
                 const title = binding.bookLabel?.value;
                 // Regex helps remove books with wikidata id. Filtering thru the noise of books with little info
-                if (!bookId || !title || /^Q\d+$/.test(title)) return acc;  
+                if (!bookId || !title || /^Q\d+$/.test(title)) return acc;
 
                 const existingBook = acc.get(bookId);
 
@@ -80,8 +80,8 @@ export const getBooksByLocation = async (wikidataId: string, locationName: strin
                     }
 
                     const newAuthor = binding.authorLabel?.value;
-                    if (newAuthor && !existingBook.author.includes(newAuthor)) {
-                        existingBook.author += `, ${newAuthor}`; 
+                    if (newAuthor && !existingBook.author.includes(newAuthor) && !/^Q\d+$/.test(newAuthor)) {
+                        existingBook.author = existingBook.author === 'Unknown' ? newAuthor : `${existingBook.author}, ${newAuthor}`;
                     }
                 } else {
                     let publicationYear = null;
@@ -92,12 +92,15 @@ export const getBooksByLocation = async (wikidataId: string, locationName: strin
                         }
                     }
 
+                    const rawAuthor = binding.authorLabel?.value;
+                    const cleanAuthor = (rawAuthor && !/^Q\d+$/.test(rawAuthor)) ? rawAuthor : 'Unknown';
+
                     acc.set(bookId, {
                         wikidataId: bookId,
                         isbn: binding.isbn13?.value || binding.isbn10?.value || null,
                         title: title,
-                        author: binding.authorLabel?.value || 'Unknown',
-                        location: locationName, 
+                        author: cleanAuthor,
+                        location: locationName,
                         coordinates: parseCoordinates(binding.coordinates?.value),
                         genres: binding.genreLabel?.value ? [binding.genreLabel.value] : [],
                         publicationYear
@@ -107,7 +110,7 @@ export const getBooksByLocation = async (wikidataId: string, locationName: strin
                 return acc;
             }, new Map<string, WikiDataDTO>()).values()
         );
-        
+
     } catch (error) {
         console.error(`Error fetching books by location ${wikidataId}: ${error}`);
         throw error;

--- a/literary-travels-ui/src/components/BookCard.test.tsx
+++ b/literary-travels-ui/src/components/BookCard.test.tsx
@@ -16,6 +16,17 @@ vi.mock('swr', () => ({
     useSWRConfig: vi.fn(() => ({ mutate: vi.fn() })),
 }));
 
+vi.mock('@mantine/hooks', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@mantine/hooks')>();
+    return {
+        ...actual,
+        useIntersection: () => ({
+            ref: vi.fn(),
+            entry: { isIntersecting: true }
+        })
+    };
+});
+
 const mockBook = {
     wikidataId: 'Q12345',
     isbn: '9781234567890',

--- a/literary-travels-ui/src/components/BookCard.tsx
+++ b/literary-travels-ui/src/components/BookCard.tsx
@@ -3,7 +3,7 @@ import type { default as Book, BookMetadata, SavedBook } from "../types/Book";
 import { Badge, Button, Card, Group, Text, Box, Stack, Image, Skeleton, Anchor, Modal } from "@mantine/core";
 import useSWR, { useSWRConfig } from "swr";
 import { saveBook, removeBook, fetcher } from "../services/apiClient";
-import { useDisclosure } from "@mantine/hooks";
+import { useDisclosure, useIntersection } from "@mantine/hooks";
 
 const shakeAnimation = `
   @keyframes shake {
@@ -27,13 +27,27 @@ export const BookCard: React.FC<BookCardProps> = ({ book, isSavedView = false })
     const [status, setStatus] = useState<CardStatus>('idle');
     const [opened, { open, close }] = useDisclosure(false);
 
+    const { ref, entry } = useIntersection({
+        root: null,
+        threshold: 0.1, // adding this for when 10% of card is visible to limit Google API calls
+    });
+
+    const [hasIntersected, setHasIntersected] = useState(false)
+    useEffect(() => {
+        if (entry?.isIntersecting && !hasIntersected) setHasIntersected(true);
+    }, [entry?.isIntersecting, hasIntersected])
+
     const queryParams = new URLSearchParams();
     if (book.isbn) queryParams.append('isbn', book.isbn);
     if (book.title) queryParams.append('title', book.title);
     if (book.author) queryParams.append('author', book.author);
 
+    const fetchKey = hasIntersected 
+    ? `/api/books/metadata?${queryParams.toString()}`
+    : null;
+
     const { data: metadata, isLoading: isMetadataLoading } = useSWR<BookMetadata>(
-        `/api/books/metadata?${queryParams.toString()}`,
+        fetchKey,
         fetcher,
         {
             revalidateOnFocus: false, // Avoiding a refetch since book covers don't change (only for movie releases ofc)
@@ -89,9 +103,9 @@ export const BookCard: React.FC<BookCardProps> = ({ book, isSavedView = false })
     return (
         <>
             <style>{shakeAnimation}</style>
-            <Card style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+            <Card ref={ref} style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
                 <Card.Section>
-                    <Skeleton visible={isMetadataLoading} height={250} radius="none">
+                    <Skeleton visible={isMetadataLoading && hasIntersected} height={250} radius="none">
                         <Image
                             src={metadata?.coverUrl || book.coverUrl || 'https://placehold.co/400x600?text=No+Cover+Found'}
                             height={250}

--- a/literary-travels-ui/src/components/BookGrid.test.tsx
+++ b/literary-travels-ui/src/components/BookGrid.test.tsx
@@ -15,6 +15,17 @@ vi.mock('../services/apiClient', () => ({
     fetcher: vi.fn()
 }));
 
+vi.mock('@mantine/hooks', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@mantine/hooks')>();
+    return {
+        ...actual,
+        useIntersection: () => ({
+            ref: vi.fn(),
+            entry: { isIntersecting: true }
+        })
+    };
+});
+
 describe('BookGrid Component', () => {
     const renderWithMantine = (component: React.ReactNode) => {
         return render(<MantineProvider>{component}</MantineProvider>);


### PR DESCRIPTION
1. Data Integrity & 404 Fixes
- Added strict regex validation (/^Q\d+$/) to the `WikidataService` to catch and filter out raw Q-IDs hiding in the authorLabel field, preventing them from bleeding into the UI
- Updated the `GoogleBooksService` to intelligently drop the strict +inauthor: filter if the parsed author is "Unknown," preventing the API from explicitly searching for an author with that literal name and throwing 404s
<img width="394" height="565" alt="Screenshot 2026-04-09 at 6 03 26 PM" src="https://github.com/user-attachments/assets/75d7e2eb-6208-450b-b4df-01a7e14ace22" />


2. Performance & 429 Rate Limit Resolution
- Resolved the Google Books API N+1 burst limit issues. By implementing Mantine's `useIntersection` hook inside `BookCard.tsx`, the frontend now staggers metadata requests, fetching rich data only when a card physically enters the user's viewport

(this can also be considered the end of **Epic 3: Core Search, Metadata & Map Optimization** phase, yay!)